### PR TITLE
add support for custom logging function

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ somePostgresqlServer: {
     dialect: 'postgres',
     host   : 'localhost',
     port   : 5432,
-    logging: true
+    logging: console.log
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function(sails) {
       if (connection.options == null) {
         connection.options = {};
       }
-      connection.options.logging = sails.log.verbose; //A function that gets executed everytime Sequelize would log something.
+      connection.options.logging = connection.options.logging || sails.log.verbose; //A function that gets executed everytime Sequelize would log something.
 
       migrate = sails.config.models.migrate;
       sails.log.verbose('Migration: ' + migrate);


### PR DESCRIPTION
If there is no sails.log.verbose for logging, `logging: true` - DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log
So custom logging function could be used here.
