### PR TITLE
Add support for multiple database connection simultaneously

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,17 @@ module.exports = function (sails) {
                     return next();
                 } else {
                     var forceSync = migrate === 'drop';
-                    sequelize.sync({force: forceSync}).then(function () {
-                        return next();
-                    });
+                    if (Object.keys(global['sequelize']).length == 1) {
+                        Object.keys(global['sequelize']).forEach(function (sequelizeInstance) {
+                            sequelizeInstance.sync({force: forceSync}).then(function () {
+                                return next();
+                            });
+                        });
+                    } else {
+                        global['sequelize'].sync({force: forceSync}).then(function () {
+                            return next();
+                        });
+                    }
                 }
             });
         },

--- a/index.js
+++ b/index.js
@@ -1,92 +1,139 @@
-module.exports = function(sails) {
-  global['Sequelize'] = require('sequelize');
-  Sequelize.cls = require('continuation-local-storage').createNamespace('sails-sequelize-postgresql');
-  return {
-    initialize: function(next) {
-      var hook = this;
-      hook.initAdapters();
-      hook.initModels();
+module.exports = function (sails) {
+    global['Sequelize'] = require('sequelize');
+    Sequelize.cls = require('continuation-local-storage').createNamespace('sails-sequelize-postgresql');
+    return {
+        initialize: function (next) {
+            this.initAdapters();
+            this.initModels();
 
-      var connection, migrate, sequelize;
-      sails.log.verbose('Using connection named ' + sails.config.models.connection);
-      connection = sails.config.connections[sails.config.models.connection];
-      if (connection == null) {
-        throw new Error('Connection \'' + sails.config.models.connection + '\' not found in config/connections');
-      }
-      if (connection.options == null) {
-        connection.options = {};
-      }
-      connection.options.logging = connection.options.logging || sails.log.verbose; //A function that gets executed everytime Sequelize would log something.
+            this.reload(next);
+        },
 
-      migrate = sails.config.models.migrate;
-      sails.log.verbose('Migration: ' + migrate);
+        reload: function (next) {
+            var hook = this;
+            var defaultConnection = sails.config.connections[sails.config.models.connection]
+                , migrate = sails.config.models.migrate
+                , sequelize;
+            global['sequelize'] = {};
 
-      if (connection.url) {
-        sequelize = new Sequelize(connection.url, connection.options);
-      } else {
-        sequelize = new Sequelize(connection.database, connection.user, connection.password, connection.options);
-      }
-      global['sequelize'] = sequelize;
-      return sails.modules.loadModels(function(err, models) {
-        var modelDef, modelName, ref;
-        if (err != null) {
-          return next(err);
+            return sails.modules.loadModels(function (err, models) {
+                if (err != null) {
+                    return next(err);
+                }
+
+                defineModels(models, defaultConnection);
+
+                setAssociationsAndScope(models, hook);
+
+                if (migrate === 'safe') {
+                    return next();
+                } else {
+                    var forceSync = migrate === 'drop';
+                    sequelize.sync({force: forceSync}).then(function () {
+                        return next();
+                    });
+                }
+            });
+        },
+
+        initAdapters: function () {
+            if (sails.adapters === undefined) {
+                sails.adapters = {};
+            }
+        },
+
+        initModels: function () {
+            if (sails.models === undefined) {
+                sails.models = {};
+            }
+        },
+
+        setAssociation: function (modelDef) {
+            if (modelDef.associations != null) {
+                sails.log.verbose('Loading associations for \'' + modelDef.globalId + '\'');
+                if (typeof modelDef.associations === 'function') {
+                    modelDef.associations(modelDef);
+                }
+            }
+        },
+
+        setDefaultScope: function (modelDef) {
+            if (modelDef.defaultScope != null) {
+                sails.log.verbose('Loading default scope for \'' + modelDef.globalId + '\'');
+                var model = global[modelDef.globalId];
+                if (typeof modelDef.defaultScope === 'function') {
+                    var defaultScope = modelDef.defaultScope() || {};
+                    model.addScope('defaultScope', defaultScope, {override: true});
+                }
+            }
         }
-        for (modelName in models) {
-          modelDef = models[modelName];
-          sails.log.verbose('Loading model \'' + modelDef.globalId + '\'');
-          global[modelDef.globalId] = sequelize.define(modelDef.globalId, modelDef.attributes, modelDef.options);
-          sails.models[modelDef.globalId.toLowerCase()] = global[modelDef.globalId];
-        }
-
-        for (modelName in models) {
-          modelDef = models[modelName];
-
-          hook.setAssociation(modelDef);          
-          hook.setDefaultScope(modelDef);          
-        }
-
-        if(migrate === 'safe') {
-          return next();
-        } else {
-          var forceSync = migrate === 'drop';
-          sequelize.sync({ force: forceSync }).then(function() {
-            return next();
-          });
-        }        
-      });
-    },
-
-    initAdapters: function() {
-      if(sails.adapters === undefined) {
-        sails.adapters = {};
-      }
-    },
-
-    initModels: function() {
-      if(sails.models === undefined) {
-        sails.models = {};
-      }
-    },
-
-    setAssociation: function(modelDef) {
-      if (modelDef.associations != null) {
-        sails.log.verbose('Loading associations for \'' + modelDef.globalId + '\'');
-        if (typeof modelDef.associations === 'function') {
-          modelDef.associations(modelDef);
-        }
-      }
-    },
-
-    setDefaultScope: function(modelDef) {
-      if (modelDef.defaultScope != null) {
-        sails.log.verbose('Loading default scope for \'' + modelDef.globalId + '\'');
-        var model = global[modelDef.globalId];
-        if (typeof modelDef.defaultScope === 'function') {
-          var defaultScope = modelDef.defaultScope() || {};
-          model.addScope('defaultScope',defaultScope,{override: true});
-        }
-      }
-    }
-  };
+    };
 };
+
+function defineModels(models, defaultConnection) {
+    var modelName, modelDef, sequelize, connectionName;
+
+    for (modelName in models) {
+        modelDef = models[modelName];
+        connectionName = modelDef.options.connection;
+
+        if (connectionName) {
+            sequelize = initIfNotExists(sails.config.connections[connectionName], connectionName);
+        } else {
+            sequelize = initIfNotExists(defaultConnection, sails.config.models.connection);
+        }
+
+        sails.log.verbose('Loading model \'' + modelDef.globalId + '\'');
+        global[modelDef.globalId] = sequelize.define(modelDef.globalId, modelDef.attributes, modelDef.options);
+        sails.models[modelDef.globalId.toLowerCase()] = global[modelDef.globalId];
+    }
+
+    if (Object.keys(global['sequelize']).length == 1) {
+        global['sequelize'] = sequelize;
+    }
+}
+
+function initIfNotExists(connection, connectionName) {
+    var sequelize;
+
+    if (!global['sequelize'][connectionName]) {
+        sequelize = initConnection(connection);
+        global['sequelize'][connectionName] = sequelize;
+    } else {
+        sequelize = global['sequelize'][connectionName];
+    }
+
+    return sequelize;
+}
+
+function initConnection(connection) {
+    var sequelize;
+
+    sails.log.verbose('Using connection named ' + sails.config.models.connection);
+    if (connection == null) {
+        throw new Error('Connection \'' + sails.config.models.connection + '\' not found in config/connections');
+    }
+    if (connection.options == null) {
+        connection.options = {};
+    }
+    connection.options.logging = connection.options.logging || sails.log.verbose; //A function that gets executed everytime Sequelize would log something.
+
+    if (connection.url) {
+        sequelize = new Sequelize(connection.url, connection.options);
+    } else {
+        sequelize = new Sequelize(connection.database, connection.user, connection.password, connection.options);
+    }
+
+    return sequelize;
+}
+
+function setAssociationsAndScope(models, hook) {
+    var modelName, modelDef;
+
+    for (modelName in models) {
+        modelDef = models[modelName];
+
+        hook.setAssociation(modelDef);
+        hook.setDefaultScope(modelDef);
+    }
+}

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = function (sails) {
             var defaultConnection = sails.config.connections[sails.config.models.connection]
                 , migrate = sails.config.models.migrate
                 , sequelize;
+            /* Declare the global sequelize object */
             global['sequelize'] = {};
 
             return sails.modules.loadModels(function (err, models) {
@@ -21,8 +22,15 @@ module.exports = function (sails) {
                     return next(err);
                 }
 
+                /*
+                 * Loop through the existing models, initialize sequelize connection for each new connection defined in the
+                 * models and then define and inject the models
+                 */
                 defineModels(models, defaultConnection);
 
+                /*
+                 * Loop through the existing models and initialize the declared associations and scopes
+                 */
                 setAssociationsAndScope(models, hook);
 
                 if (migrate === 'safe') {
@@ -78,29 +86,58 @@ module.exports = function (sails) {
     };
 };
 
+/**
+ * Initializes sequelize connection instances and defines the models.
+ *
+ * Loop through the existing models, initialize sequelize connection for each new (non-existing in the global sequelize
+ * connection instances pool) connection defined in the models and then define and inject the models.
+ *
+ * @param {list}    models            A list of the existing models
+ * @param {object}  defaultConnection The default connection object declared in sails.config.models
+ */
 function defineModels(models, defaultConnection) {
     var modelName, modelDef, sequelize, connectionName;
 
     for (modelName in models) {
         modelDef = models[modelName];
+        // Get current model connection
         connectionName = modelDef.options.connection;
 
+        /*
+         * If a connection was defined in the model - init a connection with that connection name.
+         * Otherwise - with the default one
+         */
         if (connectionName) {
             sequelize = initIfNotExists(sails.config.connections[connectionName], connectionName);
         } else {
             sequelize = initIfNotExists(defaultConnection, sails.config.models.connection);
         }
 
+        /* Define the models and add them to the global models pool */
         sails.log.verbose('Loading model \'' + modelDef.globalId + '\'');
         global[modelDef.globalId] = sequelize.define(modelDef.globalId, modelDef.attributes, modelDef.options);
         sails.models[modelDef.globalId.toLowerCase()] = global[modelDef.globalId];
     }
 
+    /*
+     * If there is only 1 connection in the global sequelize connections pool, it means there's no multiple data stores
+     * for this server, so just assign the current sequelize instance to the global sequelize variable, so that everything
+     * works as before for people's projects.
+     */
     if (Object.keys(global['sequelize']).length == 1) {
         global['sequelize'] = sequelize;
     }
 }
 
+/**
+ * Checks if a connection instance with the current connection name already exists in the global sequelize connections
+ * pool. If yes - just grab it from the pool and return it. Otherwise - initialize a new connection instance, add it to
+ * the global pool and return it.
+ *
+ * @param {object}  connection      An object that holds the options for the specific connections to be initialized
+ * @param {string}  connectionName  The name of the specific connection to check against
+ * @returns {object}  sequelize     The sequelize connection instance
+ */
 function initIfNotExists(connection, connectionName) {
     var sequelize;
 
@@ -114,6 +151,12 @@ function initIfNotExists(connection, connectionName) {
     return sequelize;
 }
 
+/**
+ * Initializes a new sequelize connection instance and returns it.
+ *
+ * @param {object}  connection  An object that holds the options for the specific connections to be initialized
+ * @returns {object}    sequelize   The sequelize connection instance
+ */
 function initConnection(connection) {
     var sequelize;
 
@@ -135,6 +178,12 @@ function initConnection(connection) {
     return sequelize;
 }
 
+/**
+ * Loops through the existing models and initializes the declared associations and scopes.
+ *
+ * @param {list}    models  A list of the existing models, as objects
+ * @param {object}  hook    This hook, yeah!
+ */
 function setAssociationsAndScope(models, hook) {
     var modelName, modelDef;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-sequelize",
-  "version": "1.0.1",
+  "version": "2.0.1",
   "description": "Sails.js hook to use sequelize ORM",
   "main": "index.js",
   "sails": {


### PR DESCRIPTION
Implement support for multiple data store connections, if defined.
If there are different connections defined in the models (eg. `User.options.connection = 'myMySqlConn'` and `Store.options.connection = 'myPostgresConn'`), then it will search for these connections in the `sails.config.connections` file and initialize a sequelize connection instance for each data store. And it will add each connection instance to the `global['sequelize']` pool as `global['sequelize'].myMySqlConn`, etc.

If there's no connection property defined in a model - it will use the default connection defined in `sails.config.models`. 

If there's only one connection defined at all, it will have this connection instance as it was before - simply as `global['sequelize']`. I made it this way so that current projects of people don't break after update (unless they decide to use multiple data store connections. Then they'll have to do some changes in their code).

I bumped up the version with a _major_ update because if someone decides to use multiple connections, then it's not completely backwards-compatile (because of the `global['sequelize']` pool of sequelize connection instances). If people remain with single data store connections, then everything works backwards-compatible and noone needs to make any changes. :)

P.S. Please tag the merge commit when/if you decide to merge (for easier reference in package lists).
