### PR TITLE
Updated hook to be compatible with Sequelize v4

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,50 @@
+{
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": ["error", 2, {"SwitchCase": 1}],
+        "quotes": ["error", "single"],
+        "linebreak-style": ["error", "unix"],
+        "semi": ["error", "always"],
+        "no-unused-vars": ["warn", {"vars": "all", "args": "none"}],
+        "no-console": "off",
+        "curly": "warn",
+        "radix": "error",
+        "wrap-iife": ["error", "outside"],
+        "no-undefined": "error",
+        "no-use-before-define": "error",
+        "array-bracket-spacing": ["warn", "never"],
+        "block-spacing": ["warn", "always"],
+        "comma-spacing": ["warn", { "before": false, "after": true }],
+        "comma-style": ["warn", "last"],
+        "computed-property-spacing": ["warn", "never"],
+        "consistent-this": ["warn", "self"],
+        "eol-last": "warn",
+        "max-depth": ["error", 5],
+        "max-nested-callbacks": ["error", 5],
+        "max-params": ["error", 5],
+        "no-trailing-spaces": ["warn", { "skipBlankLines": true }],
+        "object-curly-spacing": ["warn", "always"],
+        "keyword-spacing": ["warn", { "before": true, "after": true, "overrides": {} }],
+        "space-before-blocks": "warn",
+        "space-before-function-paren": "warn",
+        "space-in-parens": ["warn", "never"],
+        "space-infix-ops": "warn",
+        "space-unary-ops": ["warn", { "words": true, "nonwords": false }]
+    },
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module"
+    },
+    "env": {
+        "es6": true,
+        "commonjs": true,
+        "node": true,
+        "mocha": true
+    },
+    "globals": {
+        "Sequelize": true,
+        "Image": true,
+        "User": true,
+        "UserGroup": true
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "node"
 addons:
   postgresql: "9.3"
 before_install:

--- a/index.js
+++ b/index.js
@@ -1,22 +1,25 @@
-module.exports = function(sails) {
-  global['Sequelize'] = require('sequelize');
+module.exports = function (sails) {
+  global.Sequelize = require('sequelize');
   Sequelize.cls = require('continuation-local-storage').createNamespace('sails-sequelize-postgresql');
   return {
-    initialize: function(next) {
-      var hook = this;
+    initialize: function (next) {
+      var connection, migrate, sequelize,
+        sequelizeMajVersion = parseInt(Sequelize.version.split('.')[0], 10),
+        hook = this;
+
       hook.initAdapters();
       hook.initModels();
 
-      var connection, migrate, sequelize;
       sails.log.verbose('Using connection named ' + sails.config.models.connection);
       connection = sails.config.connections[sails.config.models.connection];
-      if (connection == null) {
+      if (!connection) {
         throw new Error('Connection \'' + sails.config.models.connection + '\' not found in config/connections');
       }
-      if (connection.options == null) {
+      if (!connection.options) {
         connection.options = {};
       }
-      connection.options.logging = connection.options.logging || sails.log.verbose; //A function that gets executed everytime Sequelize would log something.
+      //A function that gets executed everytime Sequelize would log something.
+      connection.options.logging = connection.options.logging || sails.log.verbose;
 
       migrate = sails.config.models.migrate;
       sails.log.verbose('Migration: ' + migrate);
@@ -26,51 +29,62 @@ module.exports = function(sails) {
       } else {
         sequelize = new Sequelize(connection.database, connection.user, connection.password, connection.options);
       }
-      global['sequelize'] = sequelize;
-      return sails.modules.loadModels(function(err, models) {
-        var modelDef, modelName, ref;
-        if (err != null) {
+      global.sequelize = sequelize;
+      return sails.modules.loadModels(function (err, models) {
+        var modelDef, modelName, modelClass, cm, im;
+        if (err) {
           return next(err);
         }
         for (modelName in models) {
           modelDef = models[modelName];
           sails.log.verbose('Loading model \'' + modelDef.globalId + '\'');
-          global[modelDef.globalId] = sequelize.define(modelDef.globalId, modelDef.attributes, modelDef.options);
-          sails.models[modelDef.globalId.toLowerCase()] = global[modelDef.globalId];
+          modelClass = sequelize.define(modelDef.globalId, modelDef.attributes, modelDef.options);
+
+          if (sequelizeMajVersion >= 4) {
+            for (cm in modelDef.options.classMethods) {
+              modelClass[cm] = modelDef.options.classMethods[cm];
+            }
+
+            for (im in modelDef.options.instanceMethods) {
+              modelClass.prototype[im] = modelDef.options.instanceMethods[im];
+            }
+          }
+
+          global[modelDef.globalId] = modelClass;
+          sails.models[modelDef.globalId.toLowerCase()] = modelClass;
         }
 
         for (modelName in models) {
           modelDef = models[modelName];
-
-          hook.setAssociation(modelDef);          
-          hook.setDefaultScope(modelDef);          
+          hook.setAssociation(modelDef);
+          hook.setDefaultScope(modelDef);
         }
 
-        if(migrate === 'safe') {
+        if (migrate === 'safe') {
           return next();
         } else {
           var forceSync = migrate === 'drop';
-          sequelize.sync({ force: forceSync }).then(function() {
+          sequelize.sync({ force: forceSync }).then(function () {
             return next();
           });
-        }        
+        }
       });
     },
 
-    initAdapters: function() {
-      if(sails.adapters === undefined) {
+    initAdapters: function () {
+      if (sails.adapters === undefined) {
         sails.adapters = {};
       }
     },
 
-    initModels: function() {
-      if(sails.models === undefined) {
+    initModels: function () {
+      if (sails.models === undefined) {
         sails.models = {};
       }
     },
 
-    setAssociation: function(modelDef) {
-      if (modelDef.associations != null) {
+    setAssociation: function (modelDef) {
+      if (modelDef.associations !== null) {
         sails.log.verbose('Loading associations for \'' + modelDef.globalId + '\'');
         if (typeof modelDef.associations === 'function') {
           modelDef.associations(modelDef);
@@ -78,13 +92,13 @@ module.exports = function(sails) {
       }
     },
 
-    setDefaultScope: function(modelDef) {
-      if (modelDef.defaultScope != null) {
+    setDefaultScope: function (modelDef) {
+      if (modelDef.defaultScope !== null) {
         sails.log.verbose('Loading default scope for \'' + modelDef.globalId + '\'');
         var model = global[modelDef.globalId];
         if (typeof modelDef.defaultScope === 'function') {
           var defaultScope = modelDef.defaultScope() || {};
-          model.addScope('defaultScope',defaultScope,{override: true});
+          model.addScope('defaultScope', defaultScope, { override: true });
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -17,16 +17,18 @@
   "author": "Gergely Munkacsy",
   "license": "MIT",
   "devDependencies": {
-    "mocha": "^2.2.5",
-    "pg": "^4.4.0",
+    "json3": "^3.3.2",
+    "minimatch": "^3.0.4",
+    "mocha": "^3.4.2",
+    "pg": "^6.4.0",
     "pg-hstore": "^2.3.2",
-    "sails": "^0.11.0",
-    "should": "^7.0.2",
-    "supertest": "^1.0.1"
+    "sails": "^0.11.5",
+    "should": "^11.2.1",
+    "supertest": "^3.0.0"
   },
   "dependencies": {
     "continuation-local-storage": "^3.1.4",
-    "sequelize": "^3.5.1"
+    "sequelize": "^4.2.1"
   },
   "directories": {
     "test": "test"

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -1,12 +1,12 @@
 var Sails = require('./fixtures/sample-app/app').sails;
 
-describe('Sails.js Sequelize hook tests ::', function() {
+describe('Sails.js Sequelize hook tests ::', function () {
 
   // Var to hold a running sails app instance
   var sails;
 
   // Before running any tests, attempt to lift Sails
-  before(function(done) {
+  before(function (done) {
 
     // Hook will timeout in 10 seconds
     this.timeout(11000);
@@ -14,17 +14,17 @@ describe('Sails.js Sequelize hook tests ::', function() {
     // Attempt to lift sails
     Sails().lift({
       hooks: {
-        "sequelize": require('../'),
+        'sequelize': require('../'),
         // Load the hook
-        "orm": false,
-        "pubsub": false,
+        'orm': false,
+        'pubsub': false,
         // Skip grunt (unless your hook uses it)
-        "grunt": false,
+        'grunt': false,
       }
-    },function (err, _sails) {
-        if (err) return done(err);
-        sails = _sails;
-        return done(err, sails);
+    }, function (err, _sails) {
+      if (err) { return done(err); }
+      sails = _sails;
+      return done(err, sails);
     });
   });
 
@@ -34,7 +34,7 @@ describe('Sails.js Sequelize hook tests ::', function() {
   });
 
   // Test that Sails can lift with the hook in place
-  it('sails does not crash', function() {
+  it('sails does not crash', function () {
     return true;
   });
 });

--- a/test/fixtures/sample-app/api/models/Image.js
+++ b/test/fixtures/sample-app/api/models/Image.js
@@ -1,25 +1,25 @@
 /**
-* Image.js
-*
-* @description :: TODO: You might write a short summary of how this model works and what it represents here.
-* @docs        :: http://sailsjs.org/#!documentation/models
-*/
+ * Image.js
+ *
+ * @description :: TODO: You might write a short summary of how this model works and what it represents here.
+ * @docs        :: http://sailsjs.org/#!documentation/models
+ */
 
 module.exports = {
-  attributes: {
-  	url: {
-  		type: Sequelize.STRING
-  	}  	
+  attributes  : {
+    url: {
+      type: Sequelize.STRING
+    }
   },
   associations: function () {
-	Image.belongsTo(User, {foreignKey: 'owner'});
+    Image.belongsTo(User, { foreignKey: 'owner' });
   },
-  options: {
+  options     : {
     freezeTableName: false,
-    tableName: 'image',
-    classMethods: {},
+    tableName      : 'image',
+    classMethods   : {},
     instanceMethods: {},
-    hooks: {}
+    hooks          : {}
   }
 };
 

--- a/test/fixtures/sample-app/api/models/User.js
+++ b/test/fixtures/sample-app/api/models/User.js
@@ -1,34 +1,34 @@
 /**
-* User.js
-*
-* @description :: TODO: You might write a short summary of how this model works and what it represents here.
-* @docs        :: http://sailsjs.org/#!documentation/models
-*/
+ * User.js
+ *
+ * @description :: TODO: You might write a short summary of how this model works and what it represents here.
+ * @docs        :: http://sailsjs.org/#!documentation/models
+ */
 
 module.exports = {
-  attributes: {
-  	name: {
-  		type: Sequelize.STRING
-  	},
-    age: {
-    	type: Sequelize.INTEGER
-    }    
-  },
-  associations: function () {
-  	User.hasMany(Image, {as: 'images', foreignKey: 'owner'});
-  },
-  defaultScope: function() {
-    return {
-      include: [
-        {model: Image, as: 'images'}
-      ]
+  attributes  : {
+    name: {
+      type: Sequelize.STRING
+    },
+    age : {
+      type: Sequelize.INTEGER
     }
   },
-  options: {
+  associations: function () {
+    User.hasMany(Image, { as: 'images', foreignKey: 'owner' });
+  },
+  defaultScope: function () {
+    return {
+      include: [
+        { model: Image, as: 'images' }
+      ]
+    };
+  },
+  options     : {
     freezeTableName: false,
-    tableName: 'user',
-    classMethods: {},
+    tableName      : 'user',
+    classMethods   : {},
     instanceMethods: {},
-    hooks: {}
+    hooks          : {}
   }
 };

--- a/test/fixtures/sample-app/api/models/UserGroup.js
+++ b/test/fixtures/sample-app/api/models/UserGroup.js
@@ -1,35 +1,35 @@
 /**
-* UserGroup.js
-*
-* @description :: TODO: You might write a short summary of how this model works and what it represents here.
-* @docs        :: http://sailsjs.org/#!documentation/models
-*/
+ * UserGroup.js
+ *
+ * @description :: TODO: You might write a short summary of how this model works and what it represents here.
+ * @docs        :: http://sailsjs.org/#!documentation/models
+ */
 
 module.exports = {
-  attributes: {
-  	name: {
-  		type: Sequelize.STRING
-  	},
+  attributes  : {
+    name: {
+      type: Sequelize.STRING
+    },
     role: {
-    	type: Sequelize.ENUM('USER', 'ADMIN')
-    }    
+      type: Sequelize.ENUM('USER', 'ADMIN')
+    }
   },
   associations: function () {
-  	UserGroup.hasMany(User, {as: 'users', foreignKey: 'group'});
+    UserGroup.hasMany(User, { as: 'users', foreignKey: 'group' });
   },
-  defaultScope: function() {
+  defaultScope: function () {
     return {
       include: [
-        {model: User, as: 'users'}
+        { model: User, as: 'users' }
       ]
     };
   },
-  options: {
+  options     : {
     freezeTableName: false,
-    tableName: 'user_group',
-    classMethods: {},
+    tableName      : 'user_group',
+    classMethods   : {},
     instanceMethods: {},
-    hooks: {}
+    hooks          : {}
   }
 };
 

--- a/test/fixtures/sample-app/app.js
+++ b/test/fixtures/sample-app/app.js
@@ -22,7 +22,7 @@
 // no matter where we actually lift from.
 process.chdir(__dirname);
 // Ensure a "sails" can be located:
-(function() {
+(function () {
   var sails;
   try {
     sails = require('sails');
@@ -55,5 +55,5 @@ process.chdir(__dirname);
   // sails.lift(rc('sails'));
   module.exports.sails = sails.Sails;
 
-})();
+}());
 

--- a/test/fixtures/sample-app/config/connections.js
+++ b/test/fixtures/sample-app/config/connections.js
@@ -1,14 +1,14 @@
 module.exports.connections = {
 
-    somePostgresqlServer: {
-        user: 'postgres',
-        password: '',
-        database: 'sequelize',
-        dialect: 'postgres',
-        options: {
-            dialect: 'postgres',
-            host   : 'localhost',
-            port   : 5432
-        }
+  somePostgresqlServer: {
+    user: 'postgres',
+    password: '',
+    database: 'sequelize',
+    dialect: 'postgres',
+    options: {
+      dialect: 'postgres',
+      host   : 'localhost',
+      port   : 5432
     }
+  }
 };

--- a/test/fixtures/sample-app/config/models.js
+++ b/test/fixtures/sample-app/config/models.js
@@ -1,6 +1,6 @@
 module.exports.models = {
 
-    connection: 'somePostgresqlServer',
+  connection: 'somePostgresqlServer',
 
-    migrate: 'drop'
+  migrate: 'drop'
 };

--- a/test/unit/controllers/ORM.test.js
+++ b/test/unit/controllers/ORM.test.js
@@ -2,9 +2,9 @@ var request = require('supertest');
 var should = require('should');
 var fixtures = require('./../../fixtures/instances.json');
 
-describe('User model', function() {
-  it('should create user instance', function(done) {
-    User.create(fixtures.user).then(function(user) {
+describe('User model', function () {
+  it('should create user instance', function (done) {
+    User.create(fixtures.user).then(function (user) {
       user.should.be.type('object');
       user.should.have.property('name', fixtures.user.name);
       user.should.have.property('id');
@@ -12,30 +12,30 @@ describe('User model', function() {
       fixtures.user = user;
 
       done();
-    }).catch(function(err) {
+    }).catch(function (err) {
       done(err);
     });
-  });  
+  });
 });
 
-describe('Image model', function() {
-  it('should create image instance', function(done) {
-    Image.create(fixtures.image).then(function(image) {
+describe('Image model', function () {
+  it('should create image instance', function (done) {
+    Image.create(fixtures.image).then(function (image) {
       image.should.be.type('object');
       image.should.have.property('url', fixtures.image.url);
       image.should.have.property('id');
 
       fixtures.image = image;
       done();
-    }).catch(function(err) {
+    }).catch(function (err) {
       done(err);
     });
   });
 });
 
-describe('UserGroup model', function() {
-  it('should create user group instance', function(done) {
-    UserGroup.create(fixtures.userGroup).then(function(userGroup) {
+describe('UserGroup model', function () {
+  it('should create user group instance', function (done) {
+    UserGroup.create(fixtures.userGroup).then(function (userGroup) {
       userGroup.should.be.type('object');
       userGroup.should.have.property('name', fixtures.userGroup.name);
       userGroup.should.have.property('id');
@@ -43,33 +43,33 @@ describe('UserGroup model', function() {
       fixtures.userGroup = userGroup;
 
       done();
-    }).catch(function(err) {
+    }).catch(function (err) {
       done(err);
     });
-  });    
+  });
 });
 
-describe('Associations', function() {
-  it('should add image to user', function(done) {
+describe('Associations', function () {
+  it('should add image to user', function (done) {
     var user = fixtures.user;
     var image = fixtures.image;
 
-    user.addImage(image).then(function() {
-      done();      
-    }).catch(function(err) {
+    user.addImage(image).then(function () {
+      done();
+    }).catch(function (err) {
       done(err);
     });
   });
 
-  it('User should contain image', function(done) {
+  it('User should contain image', function (done) {
     User.findOne({
       where: {
         id: fixtures.user.id
       },
       include: [
-      {model: Image, as: 'images'}
+        { model: Image, as: 'images' }
       ]
-    }).then(function(user) {
+    }).then(function (user) {
       user.should.have.property('images');
 
       var image = user.images.shift();
@@ -78,20 +78,20 @@ describe('Associations', function() {
 
       fixtures.user = user;
       done();
-    }).catch(function(err) {
+    }).catch(function (err) {
       done(err);
-    }); 
+    });
   });
 
-  it('Image should have owner', function(done) {
+  it('Image should have owner', function (done) {
     Image.findOne({
       where: {
         id: fixtures.image.id
       },
       include: [
-      {model: User}
+        { model: User }
       ]
-    }).then(function(image) {
+    }).then(function (image) {
       image.should.have.property('User');
       image.User.should.be.type('object');
       image.User.should.have.property('name', fixtures.user.name);
@@ -99,31 +99,31 @@ describe('Associations', function() {
       fixtures.image = image;
 
       done();
-    }).catch(function(err) {
+    }).catch(function (err) {
       done(err);
     });
   });
 
-  it('shoud add user to user group', function(done) {
+  it('shoud add user to user group', function (done) {
     var userGroup = fixtures.userGroup;
     var user = fixtures.user;
 
-    userGroup.addUser(user).then(function(userGroup) {
+    userGroup.addUser(user).then(function (userGroup) {
       done();
-    }).catch(function(err) {
+    }).catch(function (err) {
       done(err);
     });
   });
 
-  it('UserGroup should contain user', function(done) {
+  it('UserGroup should contain user', function (done) {
     UserGroup.findOne({
       where: {
         id: fixtures.userGroup.id
       },
       include: [
-      {model: User, as: 'users'}
+        { model: User, as: 'users' }
       ]
-    }).then(function(userGroup) {
+    }).then(function (userGroup) {
       userGroup.should.have.property('users');
 
       var user = userGroup.users.shift();
@@ -131,19 +131,19 @@ describe('Associations', function() {
       user.id.should.equal(fixtures.user.id);
 
       done();
-    }).catch(function(err) {
+    }).catch(function (err) {
       done(err);
     });
   });
 });
 
-describe('Default scope', function() {
-  it('User shoud contain images', function(done) {
+describe('Default scope', function () {
+  it('User shoud contain images', function (done) {
     User.findOne({
       where: {
         id: fixtures.user.id
-      }      
-    }).then(function(user) {
+      }
+    }).then(function (user) {
       user.should.have.property('images');
 
       var image = user.images.shift();
@@ -151,17 +151,17 @@ describe('Default scope', function() {
       image.should.have.property('url', fixtures.image.url);
 
       done();
-    }).catch(function(err) {
+    }).catch(function (err) {
       done(err);
-    }); 
+    });
   });
 
-  it('UserGroup shoud contain users', function(done) {
+  it('UserGroup shoud contain users', function (done) {
     UserGroup.findOne({
       where: {
         id: fixtures.userGroup.id
-      }      
-    }).then(function(userGroup) {
+      }
+    }).then(function (userGroup) {
       userGroup.should.have.property('users');
 
       var user = userGroup.users.shift();
@@ -169,17 +169,17 @@ describe('Default scope', function() {
       user.id.should.equal(fixtures.user.id);
 
       done();
-    }).catch(function(err) {
+    }).catch(function (err) {
       done(err);
-    }); 
+    });
   });
 
-  it('UserGroup shoud contain users images', function(done) {
+  it('UserGroup shoud contain users images', function (done) {
     UserGroup.findOne({
       where: {
         id: fixtures.userGroup.id
-      }      
-    }).then(function(userGroup) {
+      }
+    }).then(function (userGroup) {
       userGroup.should.have.property('users');
 
       var user = userGroup.users.shift();
@@ -192,8 +192,8 @@ describe('Default scope', function() {
       image.should.have.property('url', fixtures.image.url);
 
       done();
-    }).catch(function(err) {
+    }).catch(function (err) {
       done(err);
-    }); 
+    });
   });
 });


### PR DESCRIPTION
Hi, @festo!

I've just updated hook to work with Sequelize v4.
Sequelize V4 is a major release and it introduces new features and breaking changes. Majority of sequelize codebase has been refactored to use ES2015 features. 
Most important thing is that classMethods and instanceMethods were removed.
Also i've added eslint code quality tool config and polished code accordingly.